### PR TITLE
Listed Digital Marketing AI tools - Publish7

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@
 - [Riffusion](https://www.riffusion.com) - Stable diffusion for real-time music generation.
 - [Pollinations.AI](https://pollinations.ai) - Pollinations is a platform to generate media with the help of AI. Here you can create customized, royalty-free pieces of audio, images, 3D objects and soon fully immersive 3D environments on the fly.
 - [Coqui.AI](https://coqui.ai/) - This platform offers quick and easy voice cloning from 3 seconds of audio or the option to design a dream voice using generative AI. With a growing selection of AI voices, users can easily tune the style, pace, and emotions of any voice to their liking.
+  
 ## Video
 
 - [Runway](https://runwayml.com) - Explore more than 30+ AI powered creative tools to ideate, generate and edit content like never before.
 - [Fliki](https://fliki.ai) - Create text to video and text to speech content with ai powered voices in minutes. Get started today and create videos and voiceovers with life-like AI voices!
+
+## Digital Marketing
+
+- [Publish7](https://publish7.com/) - Discover 30+ AI-powered marketing agents designed to automate a wide range of digital marketing tasks, boosting efficiency and saving valuable time.


### PR DESCRIPTION
Listed Publish7(https://publish7.com/), supporting a list of AI agents for Marketing usecases. 